### PR TITLE
Enable the upgrade version of jquery-rails

### DIFF
--- a/geo_contrast.gemspec
+++ b/geo_contrast.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_dependency "jquery-rails", "3.1.2"
+  spec.add_dependency "jquery-rails", "~> 3.1.2"
 end


### PR DESCRIPTION
The current version of jquery-rails has some known vulnerabilities.
